### PR TITLE
Fix memoize key

### DIFF
--- a/src/memoize.php
+++ b/src/memoize.php
@@ -14,7 +14,7 @@ function memoize(callable $fn, ...$args)
 {
     static $cache = [];
 
-    $key = md5(get_class($fn) . serialize($args));
+    $key = md5(spl_object_hash($fn) . serialize($args));
 
     return $cache[$key] = array_key_exists($key, $cache) ? $cache[$key] : $fn(...$args);
 }


### PR DESCRIPTION
Doing some research I realized that `spl_object_hash` returns a different hash for 2 diferents closures:
<img width="824" alt="screen shot 2016-01-29 at 00 23 24" src="https://cloud.githubusercontent.com/assets/1331435/12662152/8f30a0e2-c61e-11e5-86ef-2010e5a41230.png">
(It look similar, but it's not the same, there's a letter of difference)

Todo: Improve the tests to tests we are allways accepting all closure types and we can serialize closure arguments.